### PR TITLE
Division by zero shows an error message

### DIFF
--- a/src/GUI/Calculator.java
+++ b/src/GUI/Calculator.java
@@ -107,7 +107,7 @@ public class Calculator extends JFrame {
 			btnInfo = new JButton("Info");
 			btnInfo.addActionListener(new ActionListener() {
 				public void actionPerformed(ActionEvent arg0) {
-					String info = "Desarrollado por Alexandro Valdés Piñeda y Gloria Santos Rosado.";
+					String info = "Desarrollado por Alexandro Valdï¿½s Piï¿½eda y Gloria Santos Rosado.";
 					JOptionPane.showMessageDialog(null,info,"Informacion",JOptionPane.INFORMATION_MESSAGE);		
 				}
 			});
@@ -367,7 +367,11 @@ public class Calculator extends JFrame {
 							sign = "";
 							break;
 						case "/":
-							Ingreso.setText(Double.toString(num1/num2));
+							if (num2 != 0) {
+								Ingreso.setText(Double.toString(num1/num2));
+							} else {
+								JOptionPane.showMessageDialog(null,"No se puede dividir por cero.", "Error", JOptionPane.ERROR_MESSAGE);
+							}
 							sign = "";
 							break;
 						case "*":


### PR DESCRIPTION
Division by 0 was priorly allowed showing a result of "Infinity" which is quite incorrect. Now doing so, displays a JOption dialog message notifyng the fact that you can't divide any number by 0. Hope this is helpful and will be merged soon.